### PR TITLE
Loop parallelization and auxiliary compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJS=jpge.o jpgd.o encoder.o
 BIN=encoder
-CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros
+CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros -fopenmp
 
 $(BIN): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJS=jpge.o jpgd.o encoder.o
 BIN=encoder
-CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros -fopenmp -freciprocal-math -ffinite-math-only
+CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros -fopenmp
 
 $(BIN): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJS=jpge.o jpgd.o encoder.o
 BIN=encoder
-CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros -fopenmp
+CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros -fopenmp -freciprocal-math -ffinite-math-only
 
 $(BIN): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OBJS=jpge.o jpgd.o encoder.o
 BIN=encoder
-CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros -fopenmp
+CXXFLAGS ?= -O3 -ffast-math -fno-signed-zeros #-fopenmp
 
 $(BIN): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^

--- a/jpge.cpp
+++ b/jpge.cpp
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include <omp.h>
 
 #define JPGE_MAX(a,b) (((a)>(b))?(a):(b))
 #define JPGE_MIN(a,b) (((a)<(b))?(a):(b))
@@ -836,6 +837,7 @@ bool jpeg_encoder::emit_end_markers()
 bool jpeg_encoder::compress_image()
 {
     for(int c=0; c < m_num_components; c++) {
+    	#pragma omp parallel for collapse(2) schedule(static)
         for (int y = 0; y < m_image[c].m_y; y+= 8) {
             for (int x = 0; x < m_image[c].m_x; x += 8) {
                 dct_t sample[64];
@@ -975,6 +977,7 @@ bool jpeg_encoder::read_image(const uint8 *image_data, int width, int height, in
         return false;
     }
 
+	#pragma omp parallel for schedule(static)
     for (int y = 0; y < height; y++) {
         if (m_num_components == 1) {
             load_mcu_Y(image_data + width * y * bpp, width, bpp, y);

--- a/jpge.cpp
+++ b/jpge.cpp
@@ -837,7 +837,7 @@ bool jpeg_encoder::emit_end_markers()
 bool jpeg_encoder::compress_image()
 {
     for(int c=0; c < m_num_components; c++) {
-    	#pragma omp parallel for collapse(2) schedule(static)
+        #pragma omp parallel for collapse(2) schedule(static)
         for (int y = 0; y < m_image[c].m_y; y+= 8) {
             for (int x = 0; x < m_image[c].m_x; x += 8) {
                 dct_t sample[64];
@@ -977,7 +977,7 @@ bool jpeg_encoder::read_image(const uint8 *image_data, int width, int height, in
         return false;
     }
 
-	#pragma omp parallel for schedule(static)
+    #pragma omp parallel for schedule(static)
     for (int y = 0; y < height; y++) {
         if (m_num_components == 1) {
             load_mcu_Y(image_data + width * y * bpp, width, bpp, y);

--- a/jpge.cpp
+++ b/jpge.cpp
@@ -23,7 +23,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+
+#if defined(_OPENMP)
 #include <omp.h>
+#endif
 
 #define JPGE_MAX(a,b) (((a)>(b))?(a):(b))
 #define JPGE_MIN(a,b) (((a)<(b))?(a):(b))
@@ -837,7 +840,9 @@ bool jpeg_encoder::emit_end_markers()
 bool jpeg_encoder::compress_image()
 {
     for(int c=0; c < m_num_components; c++) {
+        #if defined(_OPENMP)
         #pragma omp parallel for collapse(2) schedule(static)
+        #endif
         for (int y = 0; y < m_image[c].m_y; y+= 8) {
             for (int x = 0; x < m_image[c].m_x; x += 8) {
                 dct_t sample[64];
@@ -977,7 +982,9 @@ bool jpeg_encoder::read_image(const uint8 *image_data, int width, int height, in
         return false;
     }
 
+    #if defined(_OPENMP)
     #pragma omp parallel for schedule(static)
+    #endif
     for (int y = 0; y < height; y++) {
         if (m_num_components == 1) {
             load_mcu_Y(image_data + width * y * bpp, width, bpp, y);


### PR DESCRIPTION
Uses OpenMP in order to compute faster certain loops from compress_image and read_image. Also, there are two compiler flags: -ffinite-math-only and -freciprocal-math that help with floating-point operations.